### PR TITLE
Readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Build a native "Hello, World!":
 ````
     echo 'let () = print_endline "Hello, World!"' > hello.ml
     ocamlfind -toolchain rumprun ocamlopt hello.ml -o hello
-    rumpbake hw_virtio hello.bin hello
+    rumprun-bake hw_virtio hello.bin hello
 ````
 
 Run it using (for example) KVM (root may be required):
@@ -84,7 +84,7 @@ module and pthreads. A simple example:
 ````
     echo 'open Unix;; let () = print_endline (string_of_float (Unix.gettimeofday ()))' > unixtime.ml
     ocamlfind -toolchain rumprun ocamlopt -package unix -linkpkg unixtime.ml -o unixtime
-    rumpbake hw_virtio unixtime.bin unixtime
+    rumprun-bake hw_virtio unixtime.bin unixtime
 ````
 
 Run it using (for example) KVM (root may be required):
@@ -121,7 +121,7 @@ check out the _mirage-dev_ branch.
 1. `cd mirage-skeleton/console`
 2. `mirage configure --target rumprun`
 3. `make depend && make`
-4. `rumpbake hw_virtio mir-console.bin mir-console`
+4. `rumprun-bake hw_virtio mir-console.bin mir-console`
 5. `rumprun kvm -i ./mir-console.bin`
 
 ## MirageOS network stack example
@@ -129,7 +129,7 @@ check out the _mirage-dev_ branch.
 1. `cd mirage-skeleton/stackv4`
 2. `NET=socket mirage configure --target rumprun`
 3. `make depend && make`
-4. `rumpbake hw_virtio mir-stackv4.bin mir-stackv4`
+4. `rumprun-bake hw_virtio mir-stackv4.bin mir-stackv4`
 5. `rumprun kvm -i [network configuration...] ./mir-stackv4.bin`
 
 For the KVM network configuration, something like this will give you a
@@ -145,7 +145,7 @@ of the moon. YMWV.
 1. `cd mirage-skeleton/static_website`
 2. `NET=socket mirage configure --target rumprun`
 3. `make depend && make`
-4. `rumpbake hw_virtio mir-www.bin mir-www`
+4. `rumprun-bake hw_virtio mir-www.bin mir-www`
 5. `rumprun kvm -i [network configuration...] ./mir-www.bin`
 
 # Example: mirage-seal

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ platform:
   ./build-rr.sh hw
   ````
 
-2. Add the `app-tools` directory added to your `$PATH`.
+2. Add the `rumprun/bin` directory added to your `$PATH`.
 
-3. Install the `ocaml-rumprun` package, specifying a `RUMPRUN_PLATFORM` matching the rumprun toolchain you just built (look in the `app-tools` directory):
+3. Install the `ocaml-rumprun` package, specifying a `RUMPRUN_PLATFORM` matching the rumprun toolchain you just built (look in the `rumprun/bin` directory):
   
   ````
       RUMPRUN_PLATFORM=i486-rumprun-netbsdelf opam install ocaml-rumprun


### PR DESCRIPTION
I ran into some minor problems following the instructions in the README, which are addressed by the following changes:
- the binaries in the `app-tools` directory aren't executable.  Solution: use the binaries in `rumprun/bin` instead (41e3b7c).  This also fixed a failure to install `ocaml-rumprun` in the next step.
- `rumpbake` is apparently deprecated in favour of `rumprun-bake` (cd976f7)
