### PR TITLE
fix for conf-gmp when cross-compiling

### DIFF
--- a/packages/conf-gmp-rumprun.1/opam
+++ b/packages/conf-gmp-rumprun.1/opam
@@ -3,11 +3,11 @@ maintainer: "martin@lucina.net"
 homepage: "http://gmplib.org/"
 license: "GPL"
 build: [
-    [ "%{ocaml-rumprun-platform}%-configure" "./configure" "--prefix=%{ocaml-rumprun-prefix}%/lib/conf-gmp" "--disable-shared" ]
-    [ "%{ocaml-rumprun-platform}%-make" ]
+    [ "./configure" "--host=%{ocaml-rumprun-platform}%" "--prefix=%{ocaml-rumprun-prefix}%/lib/conf-gmp" "--disable-shared" ]
+    [ "make" ]
 ]
 install: [
-    [ "%{ocaml-rumprun-platform}%-make" "install" ]
+    [ "make" "install" ]
 ]
 remove: [
     [ "rm" "-rf" "%{ocaml-rumprun-prefix}%/lib/conf-gmp/include" ]


### PR DESCRIPTION
Need this fix to build conf-gmp-rumprun .
